### PR TITLE
Fix indentation error in execution provider decoding

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -170,34 +170,6 @@ def decode_execution_providers(execution_providers: List[str]) -> List[str]:
     if requested_amd and cpu_available and 'CPUExecutionProvider' not in decoded:
         decoded.append('CPUExecutionProvider')
 
-    if not decoded and normalized_execution_providers and cpu_available:
-        normalized_execution_providers.extend(provider_aliases.get(execution_provider, [execution_provider]))
-
-    # remove duplicates while preserving order
-    seen = set()
-    normalized_execution_providers = [provider for provider in normalized_execution_providers if not (provider in seen or seen.add(provider))]
-
-    available_providers = onnxruntime.get_available_providers()
-    encoded_providers = encode_execution_providers(available_providers)
-    decoded = [
-        provider
-        for provider, encoded_provider in zip(available_providers, encoded_providers)
-        if any(normalized_provider in encoded_provider for normalized_provider in normalized_execution_providers)
-    ]
-
-
-    if (
-        decoded
-        and 'CPUExecutionProvider' in available_providers
-        and 'CPUExecutionProvider' not in decoded
-        and any(
-            provider in decoded
-            for provider in ('DmlExecutionProvider', 'ROCMExecutionProvider')
-        )
-    ):
-        decoded.append('CPUExecutionProvider')
-
-main
     if not decoded and normalized_execution_providers and 'CPUExecutionProvider' in available_providers:
         print('\033[33mRequested execution provider is not available. Falling back to CPU.\033[0m')
         decoded = ['CPUExecutionProvider']


### PR DESCRIPTION
## Summary
- clean up the execution provider decoding routine to remove invalid indentation
- ensure the CPU fallback logic executes without introducing syntax errors

## Testing
- python -m compileall modules/core.py

------
https://chatgpt.com/codex/tasks/task_e_68de347da6e4832681805e7bc41428c6