### PR TITLE
Default GFPGAN face enhancer to CPU when DirectML is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ python run.py --execution-provider amd
 -   DirectML and ROCm execution currently run frame processing sequentially for
     stability. The application will automatically cap execution threads to `1`
     when these providers are selected.
+-   GFPGAN face enhancement falls back to CPU by default when DirectML is in
+    use because torch-directml cannot run the model reliably. Set the
+    environment variable `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the
+    experimental DirectML path.
 
 **OpenVINO™ Execution Provider (Intel)**
 


### PR DESCRIPTION
## Summary
- add a helper that forces the face enhancer onto CPU and gate DirectML usage behind an opt-in environment variable
- reuse the helper when DirectML inference raises to provide consistent fallback handling and messaging
- document the new DirectML override flag in the README so users know how to re-enable the experimental path

## Testing
- python -m compileall modules/processors/frame/face_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68de46d235e88326aab3b077a131446d