### PR TITLE
Clarify DirectML face enhancer CPU fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,11 @@ python run.py --execution-provider amd
     stability. The application will automatically cap execution threads to `1`
     when these providers are selected.
 -   GFPGAN face enhancement falls back to CPU by default when DirectML is in
-    use because torch-directml cannot run the model reliably. Set the
-    environment variable `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the
-    experimental DirectML path.
+    use because torch-directml cannot run the model reliably. This fallback can
+    appear to "hang" on high-resolution media because CPU inference is
+    significantly slower. Set the environment variable
+    `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the experimental DirectML
+    path if you want to try GPU acceleration instead.
 
 **OpenVINO™ Execution Provider (Intel)**
 

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -107,7 +107,14 @@ def _force_cpu_face_enhancer(
     DIRECTML_FACE_ENHANCER_FORCED_CPU = True
 
     if message:
-        update_status(message, NAME)
+        update_status(
+            (
+                f"{message}"
+                "\nContinuing with CPU fallback; this can be significantly slower, "
+                "especially on high-resolution videos."
+            ),
+            NAME,
+        )
 
     return torch.device("cpu")
 


### PR DESCRIPTION
## Summary
- update the runtime status message shown when the DirectML face enhancer falls back to CPU to explain the slowdown
- document in the README that the CPU fallback can appear to hang and how to opt into the experimental DirectML path

## Testing
- not run (documentation and messaging change only)


------
https://chatgpt.com/codex/tasks/task_e_68de49fec6708326a10f3002fd5ed994