### PR TITLE
Clarify DirectML CPU fallback progress messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,12 @@ python run.py --execution-provider amd
     stability. The application will automatically cap execution threads to `1`
     when these providers are selected.
 -   GFPGAN face enhancement falls back to CPU by default when DirectML is in
-    use because torch-directml cannot run the model reliably. Set the
-    environment variable `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the
-    experimental DirectML path.
+    use because torch-directml cannot run the model reliably. This fallback can
+    appear to "hang" on high-resolution media because CPU inference is
+    significantly slower—the UI may seem idle until the first frame completes.
+    Set the environment variable
+    `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the experimental DirectML
+    path if you want to try GPU acceleration instead.
 
 **OpenVINO™ Execution Provider (Intel)**
 

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -107,7 +107,16 @@ def _force_cpu_face_enhancer(
     DIRECTML_FACE_ENHANCER_FORCED_CPU = True
 
     if message:
-        update_status(message, NAME)
+        update_status(
+            (
+                f"{message}"
+                "\nContinuing with CPU fallback; this can be significantly slower, "
+                "especially on high-resolution videos. The interface may look"
+                " idle while the CPU works through each frame, but progress"
+                " updates will resume once the first frame finishes."
+            ),
+            NAME,
+        )
 
     return torch.device("cpu")
 


### PR DESCRIPTION
## Summary
- expand the CPU fallback status message so users know the UI may appear idle while the first frame processes
- update the README DirectML notes to explain that progress updates resume after the first CPU frame completes

## Testing
- not run (documentation and messaging changes only)

------
https://chatgpt.com/codex/tasks/task_e_68de49fec6708326a10f3002fd5ed994