### PR TITLE
Add DirectML-compatible face enhancer backend options

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,18 @@ python run.py --execution-provider amd
     stability. The application will automatically cap execution threads to `1`
     when these providers are selected.
 -   GFPGAN face enhancement falls back to CPU by default when DirectML is in
-    use because torch-directml cannot run the model reliably. Set the
-    environment variable `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the
-    experimental DirectML path.
+    use because torch-directml cannot run the model reliably. This fallback can
+    appear to "hang" on high-resolution media because CPU inference is
+    significantly slower—the UI may seem idle until the first frame completes.
+    Set the environment variable
+    `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the experimental DirectML
+    path if you want to try GPU acceleration instead.
+-   You can now switch the face enhancer backend at runtime. For AMD/DirectML
+    workflows that should stay on the GPU, run with
+    `--face-enhancer-backend codeformer-onnx` (or set
+    `DLC_FACE_ENHANCER_BACKEND=codeformer-onnx`). The first launch will download
+    the CodeFormer ONNX weights automatically, and inference uses the DirectML
+    execution provider when available.
 
 **OpenVINO™ Execution Provider (Intel)**
 
@@ -311,6 +320,9 @@ python run.py --execution-provider openvino
 -   Choose a source face image and a target image/video.
 -   Click "Start".
 -   The output will be saved in a directory named after the target video.
+-   Optional: choose an alternative face enhancer backend via
+    `--face-enhancer-backend` (for example, `codeformer-onnx` for DirectML GPU
+    inference).
 
 **2. Webcam Mode**
 

--- a/modules/core.py
+++ b/modules/core.py
@@ -19,6 +19,10 @@ import modules.globals
 import modules.metadata
 import modules.ui as ui
 from modules.processors.frame.core import get_frame_processors_modules
+from modules.processors.frame.face_enhancer_backends import (
+    AVAILABLE_FACE_ENHANCER_BACKENDS,
+    DEFAULT_FACE_ENHANCER_BACKEND,
+)
 from modules.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp, normalize_output_path
 
 if 'ROCMExecutionProvider' in modules.globals.execution_providers:
@@ -35,6 +39,14 @@ def parse_args() -> None:
     program.add_argument('-t', '--target', help='select an target image or video', dest='target_path')
     program.add_argument('-o', '--output', help='select output file or directory', dest='output_path')
     program.add_argument('--frame-processor', help='pipeline of frame processors', dest='frame_processor', default=['face_swapper'], choices=['face_swapper', 'face_enhancer'], nargs='+')
+    backend_choices = sorted(AVAILABLE_FACE_ENHANCER_BACKENDS.keys())
+    program.add_argument(
+        '--face-enhancer-backend',
+        help='implementation used for face enhancement',
+        dest='face_enhancer_backend',
+        default=DEFAULT_FACE_ENHANCER_BACKEND,
+        choices=backend_choices,
+    )
     program.add_argument('--keep-fps', help='keep original fps', dest='keep_fps', action='store_true', default=False)
     program.add_argument('--keep-audio', help='keep original audio', dest='keep_audio', action='store_true', default=True)
     program.add_argument('--keep-frames', help='keep temporary frames', dest='keep_frames', action='store_true', default=False)
@@ -64,6 +76,7 @@ def parse_args() -> None:
     modules.globals.target_path = args.target_path
     modules.globals.output_path = normalize_output_path(modules.globals.source_path, modules.globals.target_path, args.output_path)
     modules.globals.frame_processors = args.frame_processor
+    modules.globals.face_enhancer_backend = args.face_enhancer_backend
     modules.globals.headless = args.source_path or args.target_path or args.output_path
     modules.globals.keep_fps = args.keep_fps
     modules.globals.keep_audio = args.keep_audio

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -33,6 +33,7 @@ execution_threads = None
 headless = None
 log_level = "error"
 fp_ui: Dict[str, bool] = {"face_enhancer": False}
+face_enhancer_backend = "gfpgan-torch"
 camera_input_combobox = None
 webcam_preview_running = False
 show_fps = False

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -1,7 +1,6 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 import cv2
 import threading
-import gfpgan
 import os
 
 import modules.globals
@@ -11,6 +10,15 @@ from modules.face_analyser import get_one_face
 from modules.typing import Frame, Face
 import platform
 import torch
+
+from modules.processors.frame.face_enhancer_backends import (
+    AVAILABLE_FACE_ENHANCER_BACKENDS,
+    DEFAULT_FACE_ENHANCER_BACKEND,
+    BackendInferenceError,
+    BackendLoadError,
+    FaceEnhancerBackend,
+    GfpganTorchBackend,
+)
 
 TORCH_DIRECTML_AVAILABLE = False
 DIRECTML_DEVICE = None
@@ -27,8 +35,7 @@ from modules.utilities import (
     is_video,
 )
 
-FACE_ENHANCER = None
-FACE_ENHANCER_DEVICE: Optional[torch.device] = None
+FACE_ENHANCER: Optional[FaceEnhancerBackend] = None
 DIRECTML_FACE_ENHANCER_DISABLED = False
 DIRECTML_FACE_ENHANCER_FORCED_CPU = False
 THREAD_SEMAPHORE = threading.Semaphore()
@@ -46,14 +53,43 @@ ALLOW_DIRECTML_FACE_ENHANCER = (
 )
 
 
+def _get_configured_backend_id() -> str:
+    env_override = os.environ.get("DLC_FACE_ENHANCER_BACKEND", "").strip().lower()
+    if env_override:
+        if env_override in AVAILABLE_FACE_ENHANCER_BACKENDS:
+            return env_override
+        update_status(
+            (
+                f"Unknown face enhancer backend '{env_override}'. "
+                "Falling back to default."
+            ),
+            NAME,
+        )
+
+    configured = (modules.globals.face_enhancer_backend or "").strip().lower()
+    if configured in AVAILABLE_FACE_ENHANCER_BACKENDS:
+        return configured
+
+    if configured:
+        update_status(
+            (
+                f"Face enhancer backend '{configured}' is not available. "
+                f"Using '{DEFAULT_FACE_ENHANCER_BACKEND}' instead."
+            ),
+            NAME,
+        )
+
+    return DEFAULT_FACE_ENHANCER_BACKEND
+
+
 def pre_check() -> bool:
-    download_directory_path = models_dir
-    conditional_download(
-        download_directory_path,
-        [
-            "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/GFPGANv1.4.pth"
-        ],
+    backend_id = _get_configured_backend_id()
+    backend_cls = AVAILABLE_FACE_ENHANCER_BACKENDS.get(
+        backend_id, AVAILABLE_FACE_ENHANCER_BACKENDS[DEFAULT_FACE_ENHANCER_BACKEND]
     )
+    required_urls = list(backend_cls.required_model_urls())
+    if required_urls:
+        conditional_download(models_dir, required_urls)
     return True
 
 
@@ -94,30 +130,7 @@ def _directml_error_summary(error: Exception) -> str:
     return message
 
 
-def _force_cpu_face_enhancer(
-    message: Optional[str] = None, mark_disabled: bool = False
-) -> torch.device:
-    """Return a CPU device and mark DirectML as unusable when requested."""
-
-    global DIRECTML_FACE_ENHANCER_DISABLED, DIRECTML_FACE_ENHANCER_FORCED_CPU
-
-    if mark_disabled:
-        DIRECTML_FACE_ENHANCER_DISABLED = True
-
-    DIRECTML_FACE_ENHANCER_FORCED_CPU = True
-
-    if message:
-        update_status(message, NAME)
-
-    return torch.device("cpu")
-
-
-def _initialise_face_enhancer(force_device: Optional[torch.device] = None) -> Any:
-    global FACE_ENHANCER, FACE_ENHANCER_DEVICE, DIRECTML_FACE_ENHANCER_DISABLED
-    global DIRECTML_FACE_ENHANCER_FORCED_CPU
-
-    model_path = os.path.join(models_dir, "GFPGANv1.4.pth")
-
+def _select_torch_device(force_device: Optional[torch.device]) -> Tuple[torch.device, List[str]]:
     selected_device: Optional[torch.device] = None
     device_priority: List[str] = []
 
@@ -155,10 +168,9 @@ def _initialise_face_enhancer(force_device: Optional[torch.device] = None) -> An
                             "DLC_ALLOW_DIRECTML_FACE_ENHANCER=1 to override."
                         )
                     )
-                    device_priority.append("CPU (DirectML disabled)")
                 else:
                     selected_device = torch.device("cpu")
-                    device_priority.append("CPU (DirectML disabled)")
+                device_priority.append("CPU (DirectML disabled)")
             else:
                 selected_device = DIRECTML_DEVICE
                 device_priority.append("DirectML")
@@ -198,135 +210,184 @@ def _initialise_face_enhancer(force_device: Optional[torch.device] = None) -> An
             selected_device = torch.device("cpu")
             device_priority.append("CPU")
 
-    try:
-        FACE_ENHANCER = gfpgan.GFPGANer(
-            model_path=model_path, upscale=1, device=selected_device
+    if selected_device is None:
+        selected_device = torch.device("cpu")
+        if not device_priority:
+            device_priority.append("CPU")
+
+    return selected_device, device_priority
+
+
+def _force_cpu_face_enhancer(
+    message: Optional[str] = None, mark_disabled: bool = False
+) -> torch.device:
+    """Return a CPU device and mark DirectML as unusable when requested."""
+
+    global DIRECTML_FACE_ENHANCER_DISABLED, DIRECTML_FACE_ENHANCER_FORCED_CPU
+
+    if mark_disabled:
+        DIRECTML_FACE_ENHANCER_DISABLED = True
+
+    DIRECTML_FACE_ENHANCER_FORCED_CPU = True
+
+    if message:
+        update_status(
+            (
+                f"{message}"
+                "\nContinuing with CPU fallback; this can be significantly slower, "
+                "especially on high-resolution videos. The interface may look"
+                " idle while the CPU works through each frame, but progress"
+                " updates will resume once the first frame finishes."
+            ),
+            NAME,
         )
-        FACE_ENHANCER_DEVICE = selected_device
-    except Exception as directml_error:
-        if TORCH_DIRECTML_AVAILABLE and selected_device == DIRECTML_DEVICE:
-            DIRECTML_FACE_ENHANCER_DISABLED = True
-        if (
-            force_device is None
-            and TORCH_DIRECTML_AVAILABLE
-            and selected_device == DIRECTML_DEVICE
-        ):
+
+    return torch.device("cpu")
+
+
+def _initialise_face_enhancer(force_device: Optional[torch.device] = None) -> FaceEnhancerBackend:
+    global FACE_ENHANCER, DIRECTML_FACE_ENHANCER_DISABLED
+    global DIRECTML_FACE_ENHANCER_FORCED_CPU
+
+    backend_id = _get_configured_backend_id()
+    backend_cls = AVAILABLE_FACE_ENHANCER_BACKENDS.get(
+        backend_id, AVAILABLE_FACE_ENHANCER_BACKENDS[DEFAULT_FACE_ENHANCER_BACKEND]
+    )
+
+    if FACE_ENHANCER is None or not isinstance(FACE_ENHANCER, backend_cls):
+        if FACE_ENHANCER is not None:
+            FACE_ENHANCER.unload()
+        FACE_ENHANCER = backend_cls(models_dir)
+
+    device_priority: List[str] = []
+    backend = FACE_ENHANCER
+
+    if isinstance(backend, GfpganTorchBackend):
+        selected_device, device_priority = _select_torch_device(force_device)
+
+        try:
+            backend.load(device=selected_device)
+        except BackendLoadError as directml_error:
+            if TORCH_DIRECTML_AVAILABLE and selected_device == DIRECTML_DEVICE:
+                DIRECTML_FACE_ENHANCER_DISABLED = True
+            if (
+                force_device is None
+                and TORCH_DIRECTML_AVAILABLE
+                and selected_device == DIRECTML_DEVICE
+            ):
+                update_status(
+                    (
+                        "DirectML face enhancement failed, switching to CPU. "
+                        f"Details: {_directml_error_summary(directml_error.original or directml_error)}"
+                    ),
+                    NAME,
+                )
+                print(
+                    "DirectML initialisation for GFPGAN failed; "
+                    f"falling back to CPU: {directml_error.original or directml_error}"
+                )
+                backend.unload()
+                return _initialise_face_enhancer(torch.device("cpu"))
+            raise
+
+        device = backend.device
+        device_label = _device_name(device)
+        if str(device).upper() != device_label:
+            print(
+                "Selected device: "
+                f"{device_label} ({device}) and device priority: {device_priority}"
+            )
+        else:
+            print(
+                f"Selected device: {device_label} and device priority: {device_priority}"
+            )
+    else:
+        providers = modules.globals.execution_providers
+        try:
+            backend.load(execution_providers=providers)
+        except BackendLoadError as error:
+            provider_label = ", ".join(providers) if providers else "default providers"
             update_status(
                 (
-                    "DirectML face enhancement failed, switching to CPU. "
-                    f"Details: {_directml_error_summary(directml_error)}"
+                    f"Failed to initialise {backend.display_name} using {provider_label}. "
+                    f"Details: {_directml_error_summary(error.original or error)}"
                 ),
                 NAME,
             )
-            print(
-                "DirectML initialisation for GFPGAN failed; "
-                f"falling back to CPU: {directml_error}"
-            )
-            return _initialise_face_enhancer(torch.device("cpu"))
-        raise
+            raise
 
-    device_label = _device_name(selected_device)
-    if str(selected_device).upper() != device_label:
+        provider = backend.provider or "CPUExecutionProvider"
         print(
-            "Selected device: "
-            f"{device_label} ({selected_device}) and device priority: {device_priority}"
+            f"Selected backend: {backend.display_name} via {provider}"
         )
-    else:
-        print(
-            f"Selected device: {device_label} and device priority: {device_priority}"
-        )
-    return FACE_ENHANCER
+
+    return backend
 
 
-def get_face_enhancer(force_device: Optional[torch.device] = None) -> Any:
-    global FACE_ENHANCER, FACE_ENHANCER_DEVICE
+def get_face_enhancer(force_device: Optional[torch.device] = None) -> FaceEnhancerBackend:
+    global FACE_ENHANCER
 
     with THREAD_LOCK:
-        if (
-            FACE_ENHANCER is None
-            or (force_device is not None and FACE_ENHANCER_DEVICE != force_device)
+        if FACE_ENHANCER is None:
+            FACE_ENHANCER = _initialise_face_enhancer(force_device)
+        elif (
+            force_device is not None
+            and isinstance(FACE_ENHANCER, GfpganTorchBackend)
+            and FACE_ENHANCER.device != force_device
         ):
-            FACE_ENHANCER = None
-            FACE_ENHANCER_DEVICE = None
-            return _initialise_face_enhancer(force_device)
+            FACE_ENHANCER.unload()
+            FACE_ENHANCER = _initialise_face_enhancer(force_device)
 
+    # FACE_ENHANCER is guaranteed to be set at this point
+    assert FACE_ENHANCER is not None
     return FACE_ENHANCER
 
 
 def enhance_face(temp_frame: Frame) -> Frame:
-    global FACE_ENHANCER, DIRECTML_FACE_ENHANCER_DISABLED
-
     with THREAD_SEMAPHORE:
         enhancer = get_face_enhancer()
-        try:
-            _, _, temp_frame = enhancer.enhance(temp_frame, paste_back=True)
-        except RuntimeError as runtime_error:
-            error_message = str(runtime_error).lower()
-            directml_tensor_mismatch = (
-                TORCH_DIRECTML_AVAILABLE
-                and FACE_ENHANCER_DEVICE == DIRECTML_DEVICE
-                and "privateuseone" in error_message
-            )
 
-            if directml_tensor_mismatch:
-                cpu_device = _force_cpu_face_enhancer(
-                    (
-                        "DirectML face enhancement failed during inference, "
-                        "switching to CPU. "
-                        f"Details: {_directml_error_summary(runtime_error)}"
-                    ),
-                    mark_disabled=True,
-                )
-                print(
-                    "DirectML inference for GFPGAN failed due to tensor type mismatch; "
-                    f"falling back to CPU: {runtime_error}"
-                )
-                FACE_ENHANCER = None
-                enhancer = get_face_enhancer(cpu_device)
-                _, _, temp_frame = enhancer.enhance(temp_frame, paste_back=True)
-            elif (
-                TORCH_DIRECTML_AVAILABLE
-                and FACE_ENHANCER_DEVICE == DIRECTML_DEVICE
-            ):
-                cpu_device = _force_cpu_face_enhancer(
-                    (
-                        "DirectML face enhancement failed during inference, "
-                        "switching to CPU. "
-                        f"Details: {_directml_error_summary(runtime_error)}"
-                    ),
-                    mark_disabled=True,
-                )
-                print(
-                    "DirectML inference for GFPGAN failed; "
-                    f"falling back to CPU: {runtime_error}"
-                )
-                FACE_ENHANCER = None
-                enhancer = get_face_enhancer(cpu_device)
-                _, _, temp_frame = enhancer.enhance(temp_frame, paste_back=True)
-            else:
+        while True:
+            try:
+                temp_frame = enhancer.enhance(temp_frame)
+                break
+            except BackendInferenceError as backend_error:
+                original_error = backend_error.original or backend_error
+
+                if (
+                    TORCH_DIRECTML_AVAILABLE
+                    and isinstance(enhancer, GfpganTorchBackend)
+                    and enhancer.device == DIRECTML_DEVICE
+                ):
+                    error_message = str(original_error).lower()
+                    directml_tensor_mismatch = "privateuseone" in error_message
+
+                    cpu_device = _force_cpu_face_enhancer(
+                        (
+                            "DirectML face enhancement failed during inference, "
+                            "switching to CPU. "
+                            f"Details: {_directml_error_summary(original_error)}"
+                        ),
+                        mark_disabled=True,
+                    )
+
+                    if directml_tensor_mismatch:
+                        print(
+                            "DirectML inference for GFPGAN failed due to tensor type mismatch; "
+                            f"falling back to CPU: {original_error}"
+                        )
+                    else:
+                        print(
+                            "DirectML inference for GFPGAN failed; "
+                            f"falling back to CPU: {original_error}"
+                        )
+
+                    enhancer.unload()
+                    enhancer = get_face_enhancer(cpu_device)
+                    continue
+
                 raise
-        except Exception as unexpected_error:
-            if (
-                TORCH_DIRECTML_AVAILABLE
-                and FACE_ENHANCER_DEVICE == DIRECTML_DEVICE
-            ):
-                cpu_device = _force_cpu_face_enhancer(
-                    (
-                        "DirectML face enhancement failed during inference, "
-                        "switching to CPU. "
-                        f"Details: {_directml_error_summary(unexpected_error)}"
-                    ),
-                    mark_disabled=True,
-                )
-                print(
-                    "DirectML inference for GFPGAN encountered an unexpected error; "
-                    f"falling back to CPU: {unexpected_error}"
-                )
-                FACE_ENHANCER = None
-                enhancer = get_face_enhancer(cpu_device)
-                _, _, temp_frame = enhancer.enhance(temp_frame, paste_back=True)
-            else:
-                raise
+
     return temp_frame
 
 

--- a/modules/processors/frame/face_enhancer_backends.py
+++ b/modules/processors/frame/face_enhancer_backends.py
@@ -1,0 +1,234 @@
+"""Face enhancer backend implementations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import os
+from typing import Iterable, List, Optional, Sequence
+
+import numpy as np
+import onnxruntime as ort
+import torch
+
+import gfpgan
+
+from modules.typing import Frame
+
+
+class FaceEnhancerBackendError(RuntimeError):
+    """Base exception for backend errors."""
+
+    def __init__(self, message: str, original: Optional[Exception] = None) -> None:
+        super().__init__(message)
+        self.original = original
+
+
+class BackendLoadError(FaceEnhancerBackendError):
+    """Raised when a backend fails to initialise."""
+
+
+class BackendInferenceError(FaceEnhancerBackendError):
+    """Raised when a backend fails during inference."""
+
+
+class FaceEnhancerBackend(ABC):
+    """Interface for interchangeable face enhancer implementations."""
+
+    backend_id: str
+    display_name: str
+    model_urls: Sequence[str] = ()
+
+    def __init__(self, models_dir: str) -> None:
+        self.models_dir = models_dir
+
+    @classmethod
+    def id(cls) -> str:
+        return cls.backend_id
+
+    @classmethod
+    def required_model_urls(cls) -> Sequence[str]:
+        return cls.model_urls
+
+    @abstractmethod
+    def load(
+        self,
+        *,
+        device: Optional[torch.device] = None,
+        execution_providers: Iterable[str] = (),
+    ) -> None:
+        """Load underlying inference runtime."""
+
+    @abstractmethod
+    def enhance(self, frame: Frame) -> Frame:
+        """Apply enhancement and return a processed frame."""
+
+    @abstractmethod
+    def unload(self) -> None:
+        """Release any loaded resources."""
+
+    @property
+    def device(self) -> Optional[torch.device]:  # pragma: no cover - default implementation
+        return None
+
+    @property
+    def provider(self) -> Optional[str]:  # pragma: no cover - default implementation
+        return None
+
+
+class GfpganTorchBackend(FaceEnhancerBackend):
+    """Torch-based GFPGAN backend."""
+
+    backend_id = "gfpgan-torch"
+    display_name = "GFPGAN (PyTorch)"
+    model_urls = ("https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/GFPGANv1.4.pth",)
+
+    def __init__(self, models_dir: str) -> None:
+        super().__init__(models_dir)
+        self._enhancer: Optional[gfpgan.GFPGANer] = None
+        self._device: Optional[torch.device] = None
+
+    def load(
+        self,
+        *,
+        device: Optional[torch.device] = None,
+        execution_providers: Iterable[str] = (),
+    ) -> None:
+        del execution_providers
+        if device is None:
+            raise BackendLoadError("A torch device is required for GFPGAN.")
+
+        model_path = self._resolve_model_path("GFPGANv1.4.pth")
+        try:
+            self._enhancer = gfpgan.GFPGANer(model_path=model_path, upscale=1, device=device)
+            self._device = device
+        except Exception as exc:  # pragma: no cover - runtime specific
+            self._enhancer = None
+            self._device = None
+            raise BackendLoadError("Failed to initialise GFPGAN backend.", exc) from exc
+
+    def enhance(self, frame: Frame) -> Frame:
+        if self._enhancer is None:
+            raise BackendInferenceError("GFPGAN backend is not loaded.")
+        try:
+            _, _, enhanced = self._enhancer.enhance(frame, paste_back=True)
+            return enhanced
+        except Exception as exc:  # pragma: no cover - runtime specific
+            raise BackendInferenceError("GFPGAN failed during inference.", exc) from exc
+
+    def unload(self) -> None:
+        self._enhancer = None
+        self._device = None
+
+    @property
+    def device(self) -> Optional[torch.device]:
+        return self._device
+
+    def _resolve_model_path(self, filename: str) -> str:
+        return os.path.join(self.models_dir, filename)
+
+
+class CodeFormerOnnxBackend(FaceEnhancerBackend):
+    """ONNX Runtime backend for CodeFormer restoration."""
+
+    backend_id = "codeformer-onnx"
+    display_name = "CodeFormer (ONNX)"
+    model_urls = (
+        "https://huggingface.co/spaces/sczhou/CodeFormer/resolve/main/weights/codeformer-v0.1.0.onnx",
+    )
+
+    def __init__(self, models_dir: str) -> None:
+        super().__init__(models_dir)
+        self._session: Optional[ort.InferenceSession] = None
+        self._input_name: Optional[str] = None
+        self._output_name: Optional[str] = None
+        self._providers: List[str] = []
+        self._input_layout: Optional[Sequence[int]] = None
+
+    def load(
+        self,
+        *,
+        device: Optional[torch.device] = None,
+        execution_providers: Iterable[str] = (),
+    ) -> None:
+        del device
+        model_path = self._resolve_model_path("codeformer-v0.1.0.onnx")
+        providers = self._normalise_providers(execution_providers)
+        try:
+            session = ort.InferenceSession(model_path, providers=providers)
+        except FileNotFoundError as exc:
+            raise BackendLoadError("CodeFormer ONNX model not found.", exc) from exc
+        except Exception as exc:  # pragma: no cover - runtime specific
+            raise BackendLoadError("Failed to initialise CodeFormer ONNX backend.", exc) from exc
+
+        self._session = session
+        self._input_name = session.get_inputs()[0].name
+        self._output_name = session.get_outputs()[0].name
+        self._providers = list(session.get_providers())
+        self._input_layout = session.get_inputs()[0].shape
+
+    def enhance(self, frame: Frame) -> Frame:
+        if self._session is None or self._input_name is None or self._output_name is None:
+            raise BackendInferenceError("CodeFormer backend is not loaded.")
+
+        tensor = self._prepare_input(frame)
+        try:
+            output = self._session.run([self._output_name], {self._input_name: tensor})[0]
+        except Exception as exc:  # pragma: no cover - runtime specific
+            raise BackendInferenceError("CodeFormer failed during inference.", exc) from exc
+
+        return self._prepare_output(output)
+
+    def unload(self) -> None:
+        self._session = None
+        self._input_name = None
+        self._output_name = None
+        self._providers = []
+        self._input_layout = None
+
+    @property
+    def provider(self) -> Optional[str]:
+        return self._providers[0] if self._providers else None
+
+    def _resolve_model_path(self, filename: str) -> str:
+        return os.path.join(self.models_dir, filename)
+
+    def _normalise_providers(self, execution_providers: Iterable[str]) -> List[str]:
+        requested = list(execution_providers)
+        available = ort.get_available_providers()
+        if requested:
+            providers = [provider for provider in requested if provider in available]
+        else:
+            providers = []
+        if not providers:
+            providers = ["CPUExecutionProvider"]
+        return providers
+
+    def _prepare_input(self, frame: Frame) -> np.ndarray:
+        data = frame.astype(np.float32)
+        data = data / 255.0
+        if self._input_layout and len(self._input_layout) == 4:
+            layout = self._input_layout
+            if layout[1] == 3 or layout[1] == "3":
+                data = np.transpose(data, (2, 0, 1))
+            data = data[np.newaxis, ...]
+        else:
+            data = data.reshape(1, *data.shape)
+        return data.astype(np.float32)
+
+    def _prepare_output(self, output: np.ndarray) -> Frame:
+        data = output
+        if data.ndim == 4:
+            data = data[0]
+        if data.shape[0] == 3 and data.ndim == 3:
+            data = np.transpose(data, (1, 2, 0))
+        data = np.clip(data, 0.0, 1.0)
+        data = (data * 255.0).astype(np.uint8)
+        return data
+
+
+AVAILABLE_FACE_ENHANCER_BACKENDS = {
+    backend.id(): backend
+    for backend in (GfpganTorchBackend, CodeFormerOnnxBackend)
+}
+
+DEFAULT_FACE_ENHANCER_BACKEND = GfpganTorchBackend.backend_id


### PR DESCRIPTION
## Summary
- add a pluggable face enhancer backend system with separate torch GFPGAN and DirectML-friendly CodeFormer ONNX implementations
- expose a --face-enhancer-backend CLI option and default selection tracking so users can switch from GFPGAN to CodeFormer without editing code
- document the new backend choice in the README, including DirectML guidance and usage notes

## Testing
- python -m compileall modules/processors/frame/face_enhancer_backends.py modules/processors/frame/face_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68de49fec6708326a10f3002fd5ed994