### PR TITLE
Expose DirectML face enhancer override in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,12 @@ python run.py --execution-provider amd
     use because torch-directml cannot run the model reliably. This fallback can
     appear to "hang" on high-resolution media because CPU inference is
     significantly slower—the UI may seem idle until the first frame completes.
-    Set the environment variable
-    significantly slower. Set the environment variable
-    `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` to opt into the experimental DirectML
-    path if you want to try GPU acceleration instead.
+    Set the environment variable `DLC_ALLOW_DIRECTML_FACE_ENHANCER=1` or toggle
+    **Force DirectML Face Enhance** in the UI to opt into the experimental
+    DirectML path if you want to try GPU acceleration. If you still encounter a
+    tensor type mismatch after enabling the override, the installed
+    torch-directml build does not support GFPGAN and the backend will continue
+    on the CPU.
 
 **OpenVINO™ Execution Provider (Intel)**
 

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -41,3 +41,11 @@ show_mouth_mask_box = False
 mask_feather_ratio = 8
 mask_down_size = 0.50
 mask_size = 1
+
+# DirectML face enhancement can be enabled via UI or environment variable. Keep
+# the environment variable compatibility so headless executions behave the same
+# way as previous releases.
+allow_directml_face_enhancer = (
+    os.environ.get("DLC_ALLOW_DIRECTML_FACE_ENHANCER", "").strip().lower()
+    in ("1", "true", "yes", "on")
+)

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -45,12 +45,6 @@ abs_dir = os.path.dirname(os.path.abspath(__file__))
 models_dir = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(abs_dir))), "models"
 )
-ALLOW_DIRECTML_FACE_ENHANCER = (
-    os.environ.get("DLC_ALLOW_DIRECTML_FACE_ENHANCER", "").strip().lower()
-    in ("1", "true", "yes", "on")
-)
-
-
 def pre_check() -> bool:
     download_directory_path = models_dir
     conditional_download(
@@ -99,6 +93,31 @@ def _directml_error_summary(error: Exception) -> str:
     return message
 
 
+def _allow_directml_face_enhancer() -> bool:
+    env_value = os.environ.get("DLC_ALLOW_DIRECTML_FACE_ENHANCER", "").strip().lower()
+    env_enabled = env_value in ("1", "true", "yes", "on")
+    return bool(modules.globals.allow_directml_face_enhancer or env_enabled)
+
+
+def set_directml_face_enhancer_override(enabled: bool) -> None:
+    """Persist the override flag and reset cached enhancer state."""
+
+    modules.globals.allow_directml_face_enhancer = enabled
+
+    if enabled:
+        os.environ["DLC_ALLOW_DIRECTML_FACE_ENHANCER"] = "1"
+    else:
+        os.environ.pop("DLC_ALLOW_DIRECTML_FACE_ENHANCER", None)
+
+    global DIRECTML_FACE_ENHANCER_DISABLED, DIRECTML_FACE_ENHANCER_FORCED_CPU
+    DIRECTML_FACE_ENHANCER_DISABLED = False
+    DIRECTML_FACE_ENHANCER_FORCED_CPU = False
+
+    global FACE_ENHANCER, FACE_ENHANCER_DEVICE
+    FACE_ENHANCER = None
+    FACE_ENHANCER_DEVICE = None
+
+
 def _force_cpu_face_enhancer(
     message: Optional[str] = None, mark_disabled: bool = False
 ) -> torch.device:
@@ -124,6 +143,20 @@ def _force_cpu_face_enhancer(
         )
 
     return torch.device("cpu")
+
+
+def _directml_override_hint() -> str:
+    """Provide additional guidance when a forced DirectML run still fails."""
+
+    if not _allow_directml_face_enhancer():
+        return ""
+
+    return (
+        "\nDirectML override is active, but GFPGAN cannot execute on the "
+        "current torch-directml build due to incompatible tensor types. "
+        "Remove DLC_ALLOW_DIRECTML_FACE_ENHANCER or upgrade to a torch-directml "
+        "release that fixes the mismatch to avoid this fallback."
+    )
 
 
 def _initialise_face_enhancer(
@@ -161,7 +194,7 @@ def _initialise_face_enhancer(
             and TORCH_DIRECTML_AVAILABLE
             and not DIRECTML_FACE_ENHANCER_DISABLED
         ):
-            if not ALLOW_DIRECTML_FACE_ENHANCER:
+            if not _allow_directml_face_enhancer():
                 if not DIRECTML_FACE_ENHANCER_FORCED_CPU:
                     selected_device = _force_cpu_face_enhancer(
                         (
@@ -232,6 +265,7 @@ def _initialise_face_enhancer(
                 (
                     "DirectML face enhancement failed, switching to CPU. "
                     f"Details: {_directml_error_summary(directml_error)}"
+                    f"{_directml_override_hint()}"
                 ),
                 NAME,
             )
@@ -301,6 +335,7 @@ def enhance_face(temp_frame: Frame, face: Optional[Face]) -> Frame:
                         "DirectML face enhancement failed during inference, "
                         "switching to CPU. "
                         f"Details: {_directml_error_summary(runtime_error)}"
+                        f"{_directml_override_hint()}"
                     ),
                     mark_disabled=True,
                 )
@@ -322,6 +357,7 @@ def enhance_face(temp_frame: Frame, face: Optional[Face]) -> Frame:
                         "DirectML face enhancement failed during inference, "
                         "switching to CPU. "
                         f"Details: {_directml_error_summary(runtime_error)}"
+                        f"{_directml_override_hint()}"
                     ),
                     mark_disabled=True,
                 )
@@ -346,6 +382,7 @@ def enhance_face(temp_frame: Frame, face: Optional[Face]) -> Frame:
                         "DirectML face enhancement failed during inference, "
                         "switching to CPU. "
                         f"Details: {_directml_error_summary(unexpected_error)}"
+                        f"{_directml_override_hint()}"
                     ),
                     mark_disabled=True,
                 )

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -90,6 +90,12 @@ def init(start: Callable[[], None], destroy: Callable[[], None], lang: str) -> c
     return ROOT
 
 
+def _update_directml_face_enhancer_override(enabled: bool) -> None:
+    from modules.processors.frame import face_enhancer as face_enhancer_module
+
+    face_enhancer_module.set_directml_face_enhancer_override(enabled)
+
+
 def save_switch_states():
     switch_states = {
         "keep_fps": modules.globals.keep_fps,
@@ -98,6 +104,7 @@ def save_switch_states():
         "many_faces": modules.globals.many_faces,
         "map_faces": modules.globals.map_faces,
         "color_correction": modules.globals.color_correction,
+        "allow_directml_face_enhancer": modules.globals.allow_directml_face_enhancer,
         "nsfw_filter": modules.globals.nsfw_filter,
         "live_mirror": modules.globals.live_mirror,
         "live_resizable": modules.globals.live_resizable,
@@ -120,6 +127,10 @@ def load_switch_states():
         modules.globals.many_faces = switch_states.get("many_faces", False)
         modules.globals.map_faces = switch_states.get("map_faces", False)
         modules.globals.color_correction = switch_states.get("color_correction", False)
+        modules.globals.allow_directml_face_enhancer = switch_states.get(
+            "allow_directml_face_enhancer",
+            modules.globals.allow_directml_face_enhancer,
+        )
         modules.globals.nsfw_filter = switch_states.get("nsfw_filter", False)
         modules.globals.live_mirror = switch_states.get("live_mirror", False)
         modules.globals.live_resizable = switch_states.get("live_resizable", False)
@@ -361,6 +372,21 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
     )
     color_correction_switch.grid(row=2, column=0, sticky="ew", pady=12)
 
+    directml_face_enhancer_value = ctk.BooleanVar(
+        value=modules.globals.allow_directml_face_enhancer
+    )
+    directml_face_enhancer_switch = ctk.CTkSwitch(
+        right_option_column,
+        text=_("Force DirectML Face Enhance"),
+        variable=directml_face_enhancer_value,
+        cursor="hand2",
+        command=lambda: (
+            _update_directml_face_enhancer_override(directml_face_enhancer_value.get()),
+            save_switch_states(),
+        ),
+    )
+    directml_face_enhancer_switch.grid(row=3, column=0, sticky="ew", pady=12)
+
     show_fps_value = ctk.BooleanVar(value=modules.globals.show_fps)
     show_fps_switch = ctk.CTkSwitch(
         right_option_column,
@@ -372,7 +398,7 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
             save_switch_states(),
         ),
     )
-    show_fps_switch.grid(row=3, column=0, sticky="ew", pady=12)
+    show_fps_switch.grid(row=4, column=0, sticky="ew", pady=12)
 
     show_mouth_mask_box_var = ctk.BooleanVar(value=modules.globals.show_mouth_mask_box)
     show_mouth_mask_box_switch = ctk.CTkSwitch(
@@ -389,7 +415,7 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
             save_switch_states(),
         ),
     )
-    show_mouth_mask_box_switch.grid(row=4, column=0, sticky="ew", pady=(12, 0))
+    show_mouth_mask_box_switch.grid(row=5, column=0, sticky="ew", pady=(12, 0))
 
     cta_frame = ctk.CTkFrame(content, fg_color="transparent")
     cta_frame.grid(row=4, column=0, columnspan=2, sticky="ew", pady=(18, 0))


### PR DESCRIPTION
## Summary
- add a persisted global flag for the DirectML face enhancer override with environment compatibility
- expose a "Force DirectML Face Enhance" switch in the UI that resets the backend state when toggled
- document the new toggle alongside the existing environment variable option

## Testing
- python -m compileall modules/globals.py modules/ui.py modules/processors/frame/face_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68de75b3e1308326b5dfbb9f28bdab10