### PR TITLE
Refactor frame cloning for target face mappings

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from modules.typing import Frame
 from modules.cluster_analysis import find_cluster_centroids, find_closest_centroid
 from modules.utilities import get_temp_directory_path, create_temp, extract_frames, clean_temp, get_temp_frame_paths
+from modules.mapping_utils import clone_frame_entries
 from pathlib import Path
 
 FACE_ANALYSER = None
@@ -135,16 +136,7 @@ def get_unique_faces_from_target_video() -> Any:
             for frame in tqdm(frame_face_embeddings, desc=f"Mapping frame embeddings to centroids-{i}"):
                 temp.append({'frame': frame['frame'], 'faces': [face for face in frame['faces'] if face['target_centroid'] == i], 'location': frame['location']})
 
-            filtered_temp = []
-            for frame_entry in temp:
-                if isinstance(frame_entry, dict):
-                    new_entry = dict(frame_entry)
-                    faces = frame_entry.get('faces')
-                    if isinstance(faces, list):
-                        new_entry['faces'] = list(faces)
-                    filtered_temp.append(new_entry)
-                else:
-                    filtered_temp.append(frame_entry)
+            filtered_temp = clone_frame_entries(temp)
 
             modules.globals.source_target_map[i]['_all_target_faces_in_frame'] = temp
             modules.globals.source_target_map[i]['target_faces_in_frame_filtered'] = filtered_temp

--- a/modules/mapping_utils.py
+++ b/modules/mapping_utils.py
@@ -1,0 +1,25 @@
+"""Utility helpers for handling mapping-related data structures."""
+
+from typing import Any, Iterable, List, Optional
+
+
+def clone_frame_entries(frames: Optional[Iterable[Any]]) -> List[Any]:
+    """Return a shallow copy of frame entries with duplicated face lists."""
+
+    if frames is None:
+        return []
+
+    cloned_entries: List[Any] = []
+
+    for frame_entry in frames:
+        if isinstance(frame_entry, dict):
+            new_entry = dict(frame_entry)
+            faces = frame_entry.get("faces")
+            if isinstance(faces, list):
+                new_entry["faces"] = list(faces)
+            cloned_entries.append(new_entry)
+        else:
+            cloned_entries.append(frame_entry)
+
+    return cloned_entries
+


### PR DESCRIPTION
## Summary
- add a shared `clone_frame_entries` helper for mapping-related frame copies
- use the utility across face analysis and UI flows to ensure new face lists are created

## Testing
- python -m compileall modules/mapping_utils.py modules/face_analyser.py modules/ui.py
- python run.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e10e7420708326beb030f3a3a1aa49