### PR TITLE
Handle missing target faces in default_target_face

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -183,19 +183,23 @@ def default_target_face():
                 best_frame = frame
                 break
 
+        if not best_face or not best_frame:
+            continue
+
         for frame in frames:
             for face in frame['faces']:
                 if face['det_score'] > best_face['det_score']:
                     best_face = face
                     best_frame = frame
 
-        x_min, y_min, x_max, y_max = best_face['bbox']
+        if best_face and best_frame:
+            x_min, y_min, x_max, y_max = best_face['bbox']
 
-        target_frame = cv2.imread(best_frame['location'])
-        map['target'] = {
-                        'cv2' : target_frame[int(y_min):int(y_max), int(x_min):int(x_max)],
-                        'face' : best_face
-                        }
+            target_frame = cv2.imread(best_frame['location'])
+            map['target'] = {
+                            'cv2' : target_frame[int(y_min):int(y_max), int(x_min):int(x_max)],
+                            'face' : best_face
+                            }
 
 
 def dump_faces(centroids: Any, frame_face_embeddings: list):


### PR DESCRIPTION
## Summary
- skip target map entries without any detected faces when choosing a default target face
- guard the best-face selection and cropping logic so it only runs when a valid face/frame pair is available

## Testing
- python - <<'PY' (stubbed cv2/insightface; exercised default_target_face with an empty-face cluster)

------
https://chatgpt.com/codex/tasks/task_e_68e120591e848326821aa9327f193880