### PR TITLE
Fix duplicate face detector size parser definition

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -28,7 +28,6 @@ warnings.filterwarnings('ignore', category=FutureWarning, module='insightface')
 warnings.filterwarnings('ignore', category=UserWarning, module='torchvision')
 
 def _parse_face_detector_size(value: str) -> Tuple[int, int]:
-def _parse_face_detector_size(value: str) -> tuple[int, int]:
     normalized = value.lower().replace(" ", "").replace(",", "x")
     if "x" not in normalized:
         raise argparse.ArgumentTypeError(


### PR DESCRIPTION
## Summary
- remove the redundant placeholder definition for `_parse_face_detector_size`
- ensure the parser retains the intended Tuple return annotation

## Testing
- python run.py --help *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e183bdb3cc8326b5301b4ee28b9b89