### PR TITLE
Fix face detector size CLI override check

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -164,9 +164,9 @@ def load_switch_states():
             )
         )
         face_detector_size = switch_states.get("face_detector_size")
-        if not modules.globals.face_detector_size_cli_override and (
         if (
-            isinstance(face_detector_size, (list, tuple))
+            not modules.globals.face_detector_size_cli_override
+            and isinstance(face_detector_size, (list, tuple))
             and len(face_detector_size) == 2
         ):
             try:


### PR DESCRIPTION
## Summary
- combine the CLI override check with the tuple validation when loading face detector size state

## Testing
- python run.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e18582faac83268694fd828f119798