### PR TITLE
Fix duplicate face detector size formatter definition

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -404,7 +404,6 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
     ]
 
     def _format_size(size: Tuple[int, int]) -> str:
-    def _format_size(size: tuple[int, int]) -> str:
         return f"{size[0]} x {size[1]}"
 
     face_detector_size_map = {


### PR DESCRIPTION
## Summary
- remove the redundant `_format_size` definition in the face detector size UI configuration to prevent indentation issues

## Testing
- python run.py

------
https://chatgpt.com/codex/tasks/task_e_68e186f7f868832691724c8c1c52c435