### PR TITLE
Handle missing onnxruntime RuntimeException attribute fallback

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -16,7 +16,16 @@ except ImportError:  # pragma: no cover - onnxruntime may not expose the C API p
     try:
         import onnxruntime  # type: ignore
 
-        OrtRuntimeException = getattr(onnxruntime, "RuntimeException")  # type: ignore[attr-defined]
+        class _OrtRuntimeFallback(RuntimeError):
+            """Fallback when onnxruntime lacks a RuntimeException attribute."""
+
+            pass
+
+        OrtRuntimeException = getattr(
+            onnxruntime,
+            "RuntimeException",
+            _OrtRuntimeFallback,
+        )  # type: ignore[attr-defined]
     except ImportError:  # pragma: no cover - onnxruntime is entirely unavailable.
         class OrtRuntimeException(RuntimeError):
             """Fallback runtime exception when onnxruntime is unavailable."""


### PR DESCRIPTION
## Summary
- add a RuntimeError-based fallback when onnxruntime is missing the RuntimeException attribute so error handling remains functional

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e18e58f06c8326ac122809bdc3d42e