### PR TITLE
Fix option column row assignments

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -641,7 +641,7 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
             save_switch_states(),
         ),
     )
-    show_fps_switch.grid(row=5, column=0, sticky="ew", pady=12)
+    show_fps_switch.grid(row=7, column=0, sticky="ew", pady=12)
 
     show_mouth_mask_box_var = ctk.BooleanVar(value=modules.globals.show_mouth_mask_box)
     show_mouth_mask_box_switch = ctk.CTkSwitch(
@@ -658,7 +658,7 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
             save_switch_states(),
         ),
     )
-    show_mouth_mask_box_switch.grid(row=6, column=0, sticky="ew", pady=(12, 0))
+    show_mouth_mask_box_switch.grid(row=8, column=0, sticky="ew", pady=12)
 
     cta_frame = ctk.CTkFrame(content, fg_color="transparent")
     cta_frame.grid(row=4, column=0, columnspan=2, sticky="ew", pady=(18, 0))


### PR DESCRIPTION
## Summary
- adjust the right option column layout to give DirectML, CodeFormer, FPS, and mouth mask controls unique rows
- update mouth mask switch padding to maintain consistent spacing after the row changes

## Testing
- python - <<'PY'
import customtkinter as ctk
try:
    root = ctk.CTk()
    root.update_idletasks()
    root.destroy()
    print('GUI init success')
except Exception as e:
    print('GUI init failed:', e)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e20a140a1083269754c7d5cd103211