### PR TITLE
Fix grid column configuration for UI frames

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -202,7 +202,8 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
 
     content = ctk.CTkFrame(root, corner_radius=18)
     content.grid(row=0, column=0, sticky="nsew", padx=24, pady=24)
-    content.grid_columnconfigure((0, 1), weight=1)
+    for column in range(2):
+        content.grid_columnconfigure(column, weight=1)
     content.grid_rowconfigure(1, weight=1)
     content.grid_rowconfigure(3, weight=1)
 
@@ -230,7 +231,8 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
 
     preview_container = ctk.CTkFrame(content, corner_radius=16)
     preview_container.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(18, 12))
-    preview_container.grid_columnconfigure((0, 1), weight=1)
+    for column in range(2):
+        preview_container.grid_columnconfigure(column, weight=1)
     preview_container.grid_rowconfigure(1, weight=1)
 
     source_card = ctk.CTkFrame(preview_container, corner_radius=14)
@@ -292,7 +294,8 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
 
     options_frame = ctk.CTkFrame(content, corner_radius=16)
     options_frame.grid(row=3, column=0, columnspan=2, sticky="nsew")
-    options_frame.grid_columnconfigure((0, 1), weight=1)
+    for column in range(2):
+        options_frame.grid_columnconfigure(column, weight=1)
 
     left_option_column = ctk.CTkFrame(options_frame, fg_color="transparent")
     left_option_column.grid(row=0, column=0, sticky="nsew", padx=(18, 9), pady=18)
@@ -662,7 +665,8 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
 
     cta_frame = ctk.CTkFrame(content, fg_color="transparent")
     cta_frame.grid(row=4, column=0, columnspan=2, sticky="ew", pady=(18, 0))
-    cta_frame.grid_columnconfigure((0, 1, 2), weight=1)
+    for column in range(3):
+        cta_frame.grid_columnconfigure(column, weight=1)
 
     start_button = ctk.CTkButton(
         cta_frame,
@@ -684,7 +688,8 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
 
     camera_frame = ctk.CTkFrame(content, corner_radius=16)
     camera_frame.grid(row=5, column=0, columnspan=2, sticky="ew", pady=18)
-    camera_frame.grid_columnconfigure((0, 1, 2), weight=1)
+    for column in range(3):
+        camera_frame.grid_columnconfigure(column, weight=1)
 
     camera_label = ctk.CTkLabel(camera_frame, text=_("Select Camera:"), anchor="w")
     camera_label.grid(row=0, column=0, sticky="ew", padx=(18, 12), pady=18)
@@ -1197,7 +1202,8 @@ def update_popup_target(map: list, button_num: int) -> list:
 
     action_frame = ctk.CTkFrame(selection_window, fg_color="transparent")
     action_frame.grid(row=4, column=0, padx=20, pady=(10, 20), sticky="ew")
-    action_frame.grid_columnconfigure((0, 1), weight=1)
+    for column in range(2):
+        action_frame.grid_columnconfigure(column, weight=1)
 
     status_label = ctk.CTkLabel(selection_window, text="")
     status_label.grid(row=5, column=0, padx=20, pady=(0, 10))


### PR DESCRIPTION
## Summary
- configure each UI frame column individually so weight settings are applied consistently
- ensure CTA and related frames distribute space evenly across their buttons

## Testing
- python run.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e20a8633f483268a9d41f94af33cee