### PR TITLE
Add UI control for face detection threshold

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -45,6 +45,7 @@ codeformer_mask_blur = 45
 codeformer_color_strength = 1.0
 face_detector_size = (640, 640)
 face_detector_size_cli_override = False
+face_det_score_threshold = 0.5
 
 # DirectML face enhancement can be enabled via UI or environment variable. Keep
 # the environment variable compatibility so headless executions behave the same


### PR DESCRIPTION
## Summary
- configure each UI frame column individually so weight settings are applied consistently
- ensure CTA and related frames distribute space evenly across their buttons
- add a configurable face detection score threshold with persistence and a UI slider control

## Testing
- python -m compileall -f modules/face_analyser.py modules/ui.py modules/globals.py

------
https://chatgpt.com/codex/tasks/task_e_68e20a8633f483268a9d41f94af33cee