### PR TITLE
Reduce silhouette sampling to speed clustering

### DIFF
--- a/modules/cluster_analysis.py
+++ b/modules/cluster_analysis.py
@@ -10,15 +10,24 @@ def find_cluster_centroids(embeddings, max_k=10) -> Any:
     silhouette_scores = []
     K = range(1, max_k+1)
 
+    sample_kwargs = {}
+    num_embeddings = len(embeddings)
+    if num_embeddings > 1:
+        # ``silhouette_score`` performs an expensive pairwise distance computation.
+        # Sampling keeps the complexity manageable for long videos while
+        # producing a stable estimate for the optimal cluster count.
+        sample_kwargs["sample_size"] = min(120, num_embeddings)
+        sample_kwargs["random_state"] = 0
+
     for idx, k in enumerate(K):
-        kmeans = KMeans(n_clusters=k, random_state=0)
+        kmeans = KMeans(n_clusters=k, random_state=0, n_init="auto")
         kmeans.fit(embeddings)
         inertia.append(kmeans.inertia_)
         cluster_centroids.append({"k": k, "centroids": kmeans.cluster_centers_})
 
         if k > 1:
             try:
-                score = silhouette_score(embeddings, kmeans.labels_)
+                score = silhouette_score(embeddings, kmeans.labels_, **sample_kwargs)
             except ValueError:
                 continue
             silhouette_scores.append({"index": idx, "score": score})


### PR DESCRIPTION
## Summary
- shrink the silhouette_score sampling pool to at most 120 embeddings to keep clustering responsive on long videos

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e34f6a893083268874ecc60ccbdc5c